### PR TITLE
Calculate appliance run start

### DIFF
--- a/PowerHouse/Menu.c
+++ b/PowerHouse/Menu.c
@@ -28,12 +28,14 @@ typedef struct menu_item
 *  Has to be in the same order as enum MENU
 */
 menu_item menus[MENU_MAX_COUNT] = {
-    {menu_start, 's', 5, {menu_appliance, menu_data_print, menu_time, menu_carbon, menu_graph}, "Start menu", "start menu description here", "start menu help here"},
+    {menu_start, 's', 6, {menu_appliance, menu_data_print, menu_time, menu_carbon, menu_graph, menu_run_appliance}, "Start menu", "start menu description here", "start menu help here"},
     {menu_appliance, 'a', 3, { menu_appliance_print, menu_appliance_upsert, menu_appliance_remove,}, "Appliance menu", "Interact with your current appliances", "help"},
     {menu_data_print, 'p', 0, {0}, "Print data", "print data description", "print data help"},
     {menu_graph, 'g', 0, {0}, "Draw Graph", "Draws a test graph", "Graph Help"},
     {menu_time, 't', 0, {0}, "Time menu", "time menu description here", "time menu help here"},
     {menu_carbon, 'c', 0, {0}, "Carbon menu", "carbon menu description here", "carbon menu help here"},
+
+    {menu_run_appliance, 'r', 0, {0}, "Run appliance", "Calculate best time to run an appliance", "help"},
 
     {menu_appliance_print, 'p', 0, {0}, "Print appliances", "Print all current appliances", "help"},
     {menu_appliance_upsert, 'u', 0, {0}, "Set appliance", "Set or insert a new appliance", "help"},
@@ -51,6 +53,8 @@ void (*functions[MENU_MAX_COUNT])(void) = {
     &graph_draw,
     0,
     0,
+
+    &calculate_appliance_run,
 
     &appliance_print_function,
     &appliance_upsert_function,

--- a/PowerHouse/Menu.h
+++ b/PowerHouse/Menu.h
@@ -14,6 +14,8 @@ typedef enum MENU
     menu_time,
     menu_carbon,
 
+    menu_run_appliance,
+
     menu_appliance_print,
     menu_appliance_upsert,
     menu_appliance_remove,
@@ -35,5 +37,7 @@ void appliance_upsert_function(void);
 void appliance_remove_function(void);
 
 void data_print_function(void);
+
+void calculate_appliance_run(void);
 
 void graph_draw(void);

--- a/PowerHouse/MenuFunctions.c
+++ b/PowerHouse/MenuFunctions.c
@@ -2,6 +2,7 @@
 #include "appliance.h"
 #include "csvRead.h"
 #include "drawGraph.h"
+#include <math.h>
 
 #include "Menu.h"
 
@@ -68,4 +69,88 @@ void graph_draw(void)
     GraphParams input = graph_input();
 
     graph_exec(input);
+}
+
+void calculate_appliance_run(void) 
+{
+    clear_terminal();
+// specify appliance
+    int app_index = -1;
+    while (app_index == -1)
+    {
+        char app_name[50];
+        printf("Choose an appliance between among: \t[");
+        for (int i = 0; i < ApplianceCount; i++)
+            printf("%s%s%s",
+                (i % 10) == 5 ? "\n" : "", // add new line for every 10th item
+                Appliances[i].name,
+                (i + 1) == ApplianceCount ? "] \n" : ", "); //if last, terminate the list and set new line. if not last separate value with comma.
+
+        scanf(" %49s", &app_name);
+        app_index = ApplianceFind(app_name);
+    }
+
+    Appliance app = Appliances[app_index];
+
+// specify date  
+    tm day;
+    day.tm_year = 2022;
+    day.tm_min = 0;
+    day.tm_sec = 0;
+    day.tm_isdst = -1;
+    printf("Which day do you wish to see the graph for?\n");
+    printf("Please input in format MM-dd-hh\n");
+    scanf(" %d-%d-%d", &day.tm_mon, &day.tm_mday, &day.tm_hour);
+
+    day.tm_year -= 1900;
+    day.tm_mon -= 1;
+
+    time_t start_time = mktime(&day);
+    day.tm_mday += (int)floor(app.runTime);
+    time_t stop_time = mktime(&day);
+
+//run 
+    int total_rows;
+    Datapoint* data = readCSV("datafiler/DK-DK2_2022_hourly.csv", &total_rows, true);
+    Datapoint* start_point;
+    for(start_point = data; start_point < data+total_rows; start_point++)
+    {
+        if (start_point->datetime >= start_time)
+            break;
+    }
+    // calculate if running now
+    int runtime_integer = (int)floor(app.runTime);
+    double runtime_decimal = app.runTime - floor(app.runTime);
+    bool is_runtime_decimal = 0 > runtime_decimal;
+    
+    double now = 0;
+    for (int i = 0; i < app.runTime; i++)
+        now += app.wh * start_point[i].ci_lca;
+    //now += is_runtime_decimal ? start_point[runtime_integer + 1].ci_lca * runtime_decimal : 0; TODO deal with non-integer values
+
+// find best sequence
+    int best_index = 0;
+    double best_value = now, 
+        intermediate_value = now;
+
+    for (int i = 1; start_point[i].datetime <= stop_time; i++) // TODO deal with non-integer values
+    {
+        intermediate_value += start_point[runtime_integer + i].ci_lca - start_point[i - 1].ci_lca;
+        if (intermediate_value > best_value) {
+            best_index = i;
+            best_value = intermediate_value;
+        }
+    }
+
+// print best vs now
+    if (best_index) 
+    {
+        printf("The best time to turn on %s is in %d hours. \nDoing so will save the environment %.2lf gram of carbon dioxide\n", app.name, best_index, (best_value - now) * app.wh);
+    }
+    else 
+    {
+        printf("The best time on %s is now\n", app.name);
+    }
+
+    free(data);
 }

--- a/PowerHouse/MenuFunctions.c
+++ b/PowerHouse/MenuFunctions.c
@@ -98,7 +98,7 @@ void calculate_appliance_run(void)
     day.tm_min = 0;
     day.tm_sec = 0;
     day.tm_isdst = -1;
-    printf("Which day do you wish to see the graph for?\n");
+    printf("Which start time do you wish to calculate for?\n");
     printf("Please input in format MM-dd-hh\n");
     scanf(" %d-%d-%d", &day.tm_mon, &day.tm_mday, &day.tm_hour);
 
@@ -145,7 +145,7 @@ void calculate_appliance_run(void)
 // print best vs now
     if (best_index) 
     {
-        printf("The best time to turn on %s is in %d hours. \nDoing so will save the environment %.2lf gram of carbon dioxide\n", app.name, best_index, (best_value - now) * app.wh);
+        printf("The best time to turn on %s is in %d hours. \nDoing so will save the environment %.2lf gram of carbon dioxide\n", app.name, best_index, (best_value - now) * app.wh / 1000);
     }
     else 
     {


### PR DESCRIPTION
- Added menu_run_appliance enum.
- Added calculate_appliance_run function.

calculate_appliance_run takes an appliance and a date,
Then calculates when it is most environmentally friendly to run that appliance within a period.
The period is determined appliance runTime * 24.

It then outputs that the best time is either now, or a number of hours later

![image](https://github.com/Head9x/P1-projekt/assets/18309265/646984c7-5c14-4583-9e34-68de993a8186)
_____
It currently does not handle appliances with a non-integer runtime. It is also not exactly clear that it should be handled as:
```
double runTime; // time to run appliance rounded to whole hour
``` 