### PR TITLE
Csv handling

### DIFF
--- a/PowerHouse/Main.c
+++ b/PowerHouse/Main.c
@@ -54,7 +54,7 @@ void handle_exe_arguments(int argc, char* argv[])
 #if _DEBUG
 		printf("Argument [%d]: %s \n", i, argv[i]);
 #endif
-		has_next_argument = !(i < argc);
+		has_next_argument = !(i+1 >= argc);
 		if (strcmp(argv[i], argument_types[0].input) == 0) // help
 		{
 			for (int j = 0; j < 3; j++) {

--- a/PowerHouse/Main.c
+++ b/PowerHouse/Main.c
@@ -43,7 +43,7 @@ void handle_exe_arguments(int argc, char* argv[])
 
 	struct argument argument_types[] = {
 		{"h", "Help! list potential arguments"},
-		{"-d", "Sets data source file path as < -d datasource_path >"},
+		{"-d", "Sets data source file path as < -d datasource_path > or < -d datasource_path --h > if the csv file has header row"},
 		{"-s", "Sets setting file path as < -s setting_path >"}
 	};
 
@@ -72,7 +72,8 @@ void handle_exe_arguments(int argc, char* argv[])
 				printf("Missing data source path following %s argument.\n", argument_types[1].input);
 				return;
 			}
-				
+			
+			SetCSVPath(argv[i + 1], (i + 2 < argc) && strcmp(argv[i + 2], "--h"));
 			datasource_set = 1;
 		}
 		else if (strcmp(argv[i], argument_types[2].input) == 0) // settings
@@ -100,7 +101,7 @@ void handle_exe_arguments(int argc, char* argv[])
 
 	if (!datasource_set)
 	{
-		// TODO
+		SetCSVPath(NULL, true);
 		datasource_set = 1;
 	}
 }

--- a/PowerHouse/MenuFunctions.c
+++ b/PowerHouse/MenuFunctions.c
@@ -53,14 +53,13 @@ void appliance_remove_function(void)
 void data_print_function(void)
 {
     int total_rows;
-    Datapoint* data = readCSV("datafiler/DK-DK2_2022_hourly.csv", &total_rows, true);
+    Datapoint* data = GetCSVData(&total_rows);
     for (int i = 0; i < total_rows; i++)
     {
         Datapoint p = data[i];
         printf("[%d]: CI_Direct [%.2lf] CI_LCA[%.2lf] \tlow_percent [%.1lf%%] renew_percent [%.1lf%%] \t%s", // note asctime appends a new line so time has to be last
             i + 1, p.ci_direct, p.ci_lca, p.low_percent, p.renew_percent, asctime(gmtime(&p.datetime)));
     }
-    free(data);
 }
 
 
@@ -111,7 +110,7 @@ void calculate_appliance_run(void)
 
 //run 
     int total_rows;
-    Datapoint* data = readCSV("datafiler/DK-DK2_2022_hourly.csv", &total_rows, true);
+    Datapoint* data = GetCSVData(&total_rows);
     Datapoint* start_point;
     for(start_point = data; start_point < data+total_rows; start_point++)
     {
@@ -151,6 +150,4 @@ void calculate_appliance_run(void)
     {
         printf("The best time on %s is now\n", app.name);
     }
-
-    free(data);
 }

--- a/PowerHouse/SettingHandler.c
+++ b/PowerHouse/SettingHandler.c
@@ -4,8 +4,9 @@
 #include "SettingHandler.h"
 
 #define MAX_NUMBER_OF_SETTINGS 250
+#define LINE_LENGTH 1024
 
-static char* _path = "settings.txt";
+static char _path[LINE_LENGTH];
 static int number_of_settings = 0;
 static setting settings[MAX_NUMBER_OF_SETTINGS];
 
@@ -13,7 +14,7 @@ static setting settings[MAX_NUMBER_OF_SETTINGS];
 void SetSettingPath(const char* path)
 {
     number_of_settings = 0;
-	_path = path == NULL ? "settings.txt" : path;
+    strcpy(_path, path == NULL ? "settings.txt" :path);
 
     FILE* file = fopen(_path, "r");
     if (file == NULL)
@@ -24,11 +25,10 @@ void SetSettingPath(const char* path)
 
     char delimiter1[] = " ";
     char delimiter2[] = "\n";
-    char line[1024];
+    char line[LINE_LENGTH];
     char* token = NULL;
-    size_t len = 1024;
 
-    while (fgets(line, len, file) != NULL)
+    while (fgets(line, LINE_LENGTH, file) != NULL)
     {
         if (number_of_settings >= MAX_NUMBER_OF_SETTINGS) break;
 
@@ -111,12 +111,9 @@ int HasSetting(const char* key)
 // Get the setting from setting set
 const setting GetSetting(const char* key)
 {
-    auto setting _setting = { NULL, NULL };
-
     int setting_index = SettingFind(key);
     if (setting_index <= -1)
-         return _setting; // return null setting
-
+         exit(EXIT_FAILURE);
     return settings[setting_index];
 }
 

--- a/PowerHouse/csvRead.h
+++ b/PowerHouse/csvRead.h
@@ -13,4 +13,11 @@ struct Datapoint
 
 typedef struct Datapoint Datapoint;
 // Read the .csv-file. Returns a pointer to an array of the type Datapoint.
-Datapoint* readCSV(char *filename, int *rows, bool has_header);
+Datapoint* readCSV(FILE* fh, int *rows, const bool has_header);
+
+// Sets the file path to the csv data file and reads the file for further processing
+void SetCSVPath(const char* filename, const bool has_header);
+
+// Retrieves the data of the csv data file
+Datapoint* GetCSVData(int* rows_out);
+

--- a/PowerHouse/drawGraph.c
+++ b/PowerHouse/drawGraph.c
@@ -216,7 +216,7 @@ GraphParams graph_input()
 void graph_exec(GraphParams input)
 {
     int total_rows;
-    Datapoint* data = readCSV("datafiler/DK-DK2_2022_hourly.csv", &total_rows, true);
+    Datapoint* data = GetCSVData(&total_rows);
     switch (input.graph_type)
     {
     case SCATTERPLOT:
@@ -226,6 +226,4 @@ void graph_exec(GraphParams input)
     default:
         break;
     }
-
-    free(data);
 }


### PR DESCRIPTION
[Fixed handle_exe_arguments](https://github.com/Head9x/P1-projekt/commit/76077821cc65fd8dc7ceed81075e3e2cb2378a26)
Refactor of SettingHandler based on #29 

[Handle exe argument can now handle setting a csv file.](https://github.com/Head9x/P1-projekt/commit/3c313c47a6a85c6b2f4218f0480efadc264328a4)
Simplified discarding the header row in readCSV.
csvRead have been split in 3 functions:
1. SetCSVPath - Which sets the path and calls readCSV so the data is ready.
2. readCSV - Which does the reading of the csv file.
3. GetCSVData - Which simply returns the data if ready or calls readCSV & returns the result.

This means that the csv data is now persistent.