### PR TITLE
Load appliances from settings.txt

### DIFF
--- a/PowerHouse/Main.c
+++ b/PowerHouse/Main.c
@@ -52,7 +52,7 @@ int ends_with(const char* suffix, const char* str) {
 void insert_appliances_from_settings()
 {
 	setting* settings = GetAllSettings();
-	for (int i = 0; i < 50; i++)
+	for (int i = 0; i < GetSettingsCount(); i++)
 	{
 		char* ptr;
 		Appliance a;

--- a/PowerHouse/Main.c
+++ b/PowerHouse/Main.c
@@ -24,6 +24,8 @@ int main(int argc, char *argv[])
 	if (!(settings_set && datasource_set))
 		return 1;
 
+	insert_appliances_from_settings();
+
 	run_menu(menu_start);
 
 	return 0;
@@ -32,6 +34,39 @@ int main(int argc, char *argv[])
 void run_menu (int startup_menu) {
 	MenuID = startup_menu;
 	exec_menu(MenuID);
+}
+
+bool starts_with(const char* pre, const char* str)
+{
+	return strncmp(pre, str, strlen(pre)) == 0;
+}
+
+int ends_with(const char* suffix, const char* str) {
+	size_t str_len = strlen(str);
+	size_t suffix_len = strlen(suffix);
+
+	return (str_len >= suffix_len) &&
+		(!memcmp(str + str_len - suffix_len, suffix, suffix_len));
+}
+
+void insert_appliances_from_settings()
+{
+	setting* settings = GetAllSettings();
+	for (int i = 0; i < 50; i++)
+	{
+		char* ptr;
+		Appliance a;
+		if (starts_with("appliance_", settings[i].key))
+		{
+			if (ends_with("_wh", settings[i].key))
+				a.wh = strtod(settings[i].value, &ptr);
+			else if (ends_with("_runtime", settings[i].key))
+				a.runTime = strtod(settings[i].value, &ptr);
+			else
+				sprintf(a.name, "%s", settings[i].value);
+			ApplianceUpsert(a);
+		}
+	}
 }
 
 void handle_exe_arguments(int argc, char* argv[]) 

--- a/PowerHouse/Main.h
+++ b/PowerHouse/Main.h
@@ -3,6 +3,7 @@ int main(int argc, char* argv[]);
 void run_menu(int);
 
 void handle_exe_arguments(int argc, char* argv[]);
+void insert_appliances_from_settings();
 
 int settings_set = 0,
 	datasource_set = 0;

--- a/PowerHouse/MenuFunctions.c
+++ b/PowerHouse/MenuFunctions.c
@@ -30,12 +30,28 @@ void appliance_upsert_function(void)
     Appliance a;
 
     printf("Enter appliance name: ");
-    scanf(" %s", &a.name);
+    scanf(" %s", a.name);
     printf("Enter appliance wh: ");
     scanf(" %lf", &a.wh);
     printf("Enter appliance runTime: ");
     scanf(" %lf", &a.runTime);
     ApplianceUpsert(a);
+
+    char buffer_key[80];
+    char buffer_value[20];
+
+    sprintf(buffer_key, "appliance_%s", a.name);
+    sprintf(buffer_value, "%s", a.name);
+
+    UpsertSetting(buffer_key, buffer_value);
+
+    sprintf(buffer_key, "appliance_%s_wh", a.name);
+    sprintf(buffer_value, "%.0lf", a.wh);
+    UpsertSetting(buffer_key, buffer_value);
+
+    sprintf(buffer_key, "appliance_%s_runtime", a.name);
+    sprintf(buffer_value, "%.0lf", a.runTime);
+    UpsertSetting(buffer_key, buffer_value);
 
     printf("Update succesful \n");
 }
@@ -43,9 +59,19 @@ void appliance_remove_function(void)
 {
     clear_terminal();
     char c[100];
+    char buffer[100];
 
     printf("Enter appliance name: ");
     scanf(" %s", &c);
+
+    sprintf(buffer, "appliance_%s", c);
+    RemoveSetting(buffer);
+
+    sprintf(buffer, "appliance_%s_wh", c);
+    RemoveSetting(buffer);
+
+    sprintf(buffer, "appliance_%s_runtime", c);
+    RemoveSetting(buffer);
 
     printf("appliance removed %s \n", ApplianceRemove(c) ? "Successfully" : "Unsuccessfully");
 }

--- a/PowerHouse/SettingHandler.c
+++ b/PowerHouse/SettingHandler.c
@@ -10,6 +10,11 @@ static char _path[LINE_LENGTH];
 static int number_of_settings = 0;
 static setting settings[MAX_NUMBER_OF_SETTINGS];
 
+int GetSettingsCount()
+{
+    return number_of_settings;
+}
+
 // Sets the path to the settings file, use NULL for default 
 void SetSettingPath(const char* path)
 {

--- a/PowerHouse/SettingHandler.h
+++ b/PowerHouse/SettingHandler.h
@@ -6,6 +6,9 @@ typedef struct{
 		value [250];
 }setting;
 
+// Returns the number of settings
+extern int GetSettingsCount();
+
 // Sets the path to the settings file, use NULL for default 
 extern void SetSettingPath(const char* path);
 


### PR DESCRIPTION
- appliance_upsert_function now also appends the appliance to the settings file.
- appliance_remove_function now also removes the appliance from the settings file. 
- Main loads appliances from the settings file before starting the menu.

_____

This changes ensures that appliances are saved between runs. It does so by saving changes done to the appliances in the settings.txt file, and loading the appliances from that file too.

Since settings follows the format <key value>, which only allows for unique keys and only allows one value per key: each appliance will use 3 lines in the settings file. One for it's name, one for wh (watt hours) and one for runtime (runTime).